### PR TITLE
Fix: NLTK 데이터셋 다운로드 받는 코드 추가

### DIFF
--- a/08-TextSplitter/03-TokenTextSplitter.ipynb
+++ b/08-TextSplitter/03-TokenTextSplitter.ipynb
@@ -33,15 +33,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "a8919094",
    "metadata": {},
-   "outputs": [],
    "source": [
     "# data/appendix-keywords.txt 파일을 열어서 f라는 파일 객체를 생성합니다.\n",
     "with open(\"./data/appendix-keywords.txt\") as f:\n",
     "    file = f.read()  # 파일의 내용을 읽어서 file 변수에 저장합니다."
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -53,14 +53,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "d4bfdb81",
    "metadata": {},
-   "outputs": [],
    "source": [
     "# 파일으로부터 읽은 내용을 일부 출력합니다.\n",
     "print(file[:500])"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -74,10 +74,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "fe585376",
    "metadata": {},
-   "outputs": [],
    "source": [
     "from langchain_text_splitters import CharacterTextSplitter\n",
     "\n",
@@ -89,7 +87,9 @@
     ")\n",
     "# file 텍스트를 청크 단위로 분할합니다.\n",
     "texts = text_splitter.split_text(file)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -101,13 +101,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "2d531f7b",
    "metadata": {},
-   "outputs": [],
    "source": [
     "print(len(texts))  # 분할된 청크의 개수를 출력합니다."
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -119,14 +119,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "a4edccf3",
    "metadata": {},
-   "outputs": [],
    "source": [
     "# texts 리스트의 첫 번째 요소를 출력합니다.\n",
     "print(texts[0])"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -152,10 +152,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "3a3ab133",
    "metadata": {},
-   "outputs": [],
    "source": [
     "from langchain_text_splitters import TokenTextSplitter\n",
     "\n",
@@ -167,7 +165,9 @@
     "# state_of_the_union 텍스트를 청크로 분할합니다.\n",
     "texts = text_splitter.split_text(file)\n",
     "print(texts[0])  # 분할된 텍스트의 첫 번째 청크를 출력합니다."
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -195,13 +195,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "33f71a93",
    "metadata": {},
-   "outputs": [],
    "source": [
     "!pip install -qU spacy"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -213,13 +213,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "bd2d49aa",
    "metadata": {},
-   "outputs": [],
    "source": [
     "!python -m spacy download en_core_web_sm --quiet"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -231,15 +231,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "a04bd005",
    "metadata": {},
-   "outputs": [],
    "source": [
     "# data/appendix-keywords.txt 파일을 열어서 f라는 파일 객체를 생성합니다.\n",
     "with open(\"./data/appendix-keywords.txt\") as f:\n",
     "    file = f.read()  # 파일의 내용을 읽어서 file 변수에 저장합니다."
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -251,14 +251,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "92e53e9b",
    "metadata": {},
-   "outputs": [],
    "source": [
     "# 파일으로부터 읽은 내용을 일부 출력합니다.\n",
     "print(file[:350])"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -270,10 +270,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "4a9c4e8f",
    "metadata": {},
-   "outputs": [],
    "source": [
     "import warnings\n",
     "from langchain_text_splitters import SpacyTextSplitter\n",
@@ -286,7 +284,9 @@
     "    chunk_size=200,  # 청크 크기를 200으로 설정합니다.\n",
     "    chunk_overlap=50,  # 청크 간 중복을 50으로 설정합니다.\n",
     ")"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -298,15 +298,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "c7f1e84d",
    "metadata": {},
-   "outputs": [],
    "source": [
     "# text_splitter를 사용하여 file 텍스트를 분할합니다.\n",
     "texts = text_splitter.split_text(file)\n",
     "print(texts[0])  # 분할된 텍스트의 첫 번째 요소를 출력합니다."
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -322,16 +322,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "31c098ea",
    "metadata": {},
-   "outputs": [],
    "source": [
     "from langchain_text_splitters import SentenceTransformersTokenTextSplitter\n",
     "\n",
     "# 문장 분할기를 생성하고 청크 간 중복을 0으로 설정합니다.\n",
     "splitter = SentenceTransformersTokenTextSplitter(chunk_size=200, chunk_overlap=0)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -343,10 +343,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "16083e38",
    "metadata": {},
-   "outputs": [],
    "source": [
     "# data/appendix-keywords.txt 파일을 열어서 f라는 파일 객체를 생성합니다.\n",
     "with open(\"./data/appendix-keywords.txt\") as f:\n",
@@ -354,7 +352,9 @@
     "\n",
     "# 파일으로부터 읽은 내용을 일부 출력합니다.\n",
     "print(file[:350])"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -366,17 +366,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "c34c06da",
    "metadata": {},
-   "outputs": [],
    "source": [
     "count_start_and_stop_tokens = 2  # 시작과 종료 토큰의 개수를 2로 설정합니다.\n",
     "\n",
     "# 텍스트의 토큰 개수에서 시작과 종료 토큰의 개수를 뺍니다.\n",
     "text_token_count = splitter.count_tokens(text=file) - count_start_and_stop_tokens\n",
     "print(text_token_count)  # 계산된 텍스트 토큰 개수를 출력합니다."
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -388,13 +388,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "c9bc9c85",
    "metadata": {},
-   "outputs": [],
    "source": [
     "text_chunks = splitter.split_text(text=file)  # 텍스트를 청크로 분할합니다."
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -406,14 +406,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "cb6548ea",
    "metadata": {},
-   "outputs": [],
    "source": [
     "# 0번째 청크를 출력합니다.\n",
     "print(text_chunks[1])  # 분할된 텍스트 청크 중 두 번째 청크를 출력합니다."
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -442,13 +442,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "16e11572",
    "metadata": {},
-   "outputs": [],
    "source": [
     "!pip install -qU nltk"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "NLTK는 기본 설치 시 모든 데이터를 포함하지 않습니다. 이는 초기 설치 크기를 줄이고, 사용자가 필요한 데이터만 선택적으로 다운로드할 수 있게 합니다. \n",
+    "NLTK에서 사용할 데이터를 다운로드 받습니다. 다운로드는 \"~/nltk_data\"에 설치됩니다."
+   ],
+   "id": "eb7f61343cb52923"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "import nltk\n",
+    "nltk.download('punkt')"
+   ],
+   "id": "478ad71020b825e0",
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -460,10 +480,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "2291b93a",
    "metadata": {},
-   "outputs": [],
    "source": [
     "# data/appendix-keywords.txt 파일을 열어서 f라는 파일 객체를 생성합니다.\n",
     "with open(\"./data/appendix-keywords.txt\") as f:\n",
@@ -471,7 +489,9 @@
     "\n",
     "# 파일으로부터 읽은 내용을 일부 출력합니다.\n",
     "print(file[:350])"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -483,10 +503,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "402d1fd6",
    "metadata": {},
-   "outputs": [],
    "source": [
     "from langchain_text_splitters import NLTKTextSplitter\n",
     "\n",
@@ -494,7 +512,9 @@
     "    chunk_size=200,  # 청크 크기를 200으로 설정합니다.\n",
     "    chunk_overlap=0,  # 청크 간 중복을 0으로 설정합니다.\n",
     ")"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -506,15 +526,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "b86af73c",
    "metadata": {},
-   "outputs": [],
    "source": [
     "# text_splitter를 사용하여 file 텍스트를 분할합니다.\n",
     "texts = text_splitter.split_text(file)\n",
     "print(texts[0])  # 분할된 텍스트의 첫 번째 요소를 출력합니다."
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -561,13 +581,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "fef21f2b",
    "metadata": {},
-   "outputs": [],
    "source": [
     "!pip install -qU konlpy"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -579,10 +599,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "854203b5",
    "metadata": {},
-   "outputs": [],
    "source": [
     "# data/appendix-keywords.txt 파일을 열어서 f라는 파일 객체를 생성합니다.\n",
     "with open(\"./data/appendix-keywords.txt\") as f:\n",
@@ -590,7 +608,9 @@
     "\n",
     "# 파일으로부터 읽은 내용을 일부 출력합니다.\n",
     "print(file[:350])"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -602,17 +622,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "3ef8d062",
    "metadata": {},
-   "outputs": [],
    "source": [
     "import chunk\n",
     "from langchain_text_splitters import KonlpyTextSplitter\n",
     "\n",
     "# KonlpyTextSplitter를 사용하여 텍스트 분할기 객체를 생성합니다.\n",
     "text_splitter = KonlpyTextSplitter(chunk_size=200, chunk_overlap=50)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -624,14 +644,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "0c5e3c29",
    "metadata": {},
-   "outputs": [],
    "source": [
     "texts = text_splitter.split_text(file)  # 한국어 문서를 문장 단위로 분할합니다.\n",
     "print(texts[0])  # 분할된 문장 중 첫 번째 문장을 출력합니다."
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -664,16 +684,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "74a7b2ee",
    "metadata": {},
-   "outputs": [],
    "source": [
     "from transformers import GPT2TokenizerFast\n",
     "\n",
     "# GPT-2 모델의 토크나이저를 불러옵니다.\n",
     "hf_tokenizer = GPT2TokenizerFast.from_pretrained(\"gpt2\")"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -685,10 +705,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "fd437637",
    "metadata": {},
-   "outputs": [],
    "source": [
     "# data/appendix-keywords.txt 파일을 열어서 f라는 파일 객체를 생성합니다.\n",
     "with open(\"./data/appendix-keywords.txt\") as f:\n",
@@ -696,7 +714,9 @@
     "\n",
     "# 파일으로부터 읽은 내용을 일부 출력합니다.\n",
     "print(file[:350])"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -708,10 +728,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "2a5f9bd4",
    "metadata": {},
-   "outputs": [],
    "source": [
     "text_splitter = CharacterTextSplitter.from_huggingface_tokenizer(\n",
     "    # 허깅페이스 토크나이저를 사용하여 CharacterTextSplitter 객체를 생성합니다.\n",
@@ -721,7 +739,9 @@
     ")\n",
     "# state_of_the_union 텍스트를 분할하여 texts 변수에 저장합니다.\n",
     "texts = text_splitter.split_text(file)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -733,13 +753,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "404f85ef",
    "metadata": {},
-   "outputs": [],
    "source": [
     "print(texts[1])  # texts 리스트의 1 번째 요소를 출력합니다."
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   }
  ],
  "metadata": {


### PR DESCRIPTION
NLTK 데이터셋이 로컬에 없는 경우, NLTKTextSplitter.split_text(file)을 호출할 경우 오류 발생