### PR TITLE
bugfix pydantic attribute error

### DIFF
--- a/20-Projects/01-ParsingOutput/01-concept.ipynb
+++ b/20-Projects/01-ParsingOutput/01-concept.ipynb
@@ -32,7 +32,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain_core.pydantic_v1 import BaseModel, Field\n",
+    "from pydantic import BaseModel, Field\n",
     "\n",
     "\n",
     "# 이메일 본문으로부터 주요 엔티티 추출\n",


### PR DESCRIPTION
Ch5. 강의내용 프로젝트 예제 코드 (20-Projects/01-ParsingOutput/01-concept.ipynb)에서 에러가 남
from langchain_core.pydantic_v1 import BaseModel, Field
parser.get_format_instructions() 할때
